### PR TITLE
Update default.ps1

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -176,7 +176,7 @@ task CreatePackages -depends PrepareRelease  {
 	$script:packit.package_tags = "tools utilities"
 	$script:packit.package_iconUrl = "http://nuget.org/Content/Images/packageDefaultIcon.png"
 	$script:packit.versionAssemblyName = $script:packit.binaries_Location + "\gelf4net.dll"
-	invoke-packit $packageName $PackageVersion @{"log4net"="[1.2.10]"} "binaries\gelf4net.dll" @{} 
+	invoke-packit $packageName $PackageVersion @{"log4net"="1.2.10"} "binaries\gelf4net.dll" @{} 
 	#endregion
 		
 	remove-module packit


### PR DESCRIPTION
Hi,

This specific version [1.2.10] prevent the use of gelf4net with newer version of log4net, I tested it with the latest version of log4net and it worked fine.

So right now when we want install gelf4net package we have to downgrade log4net package to 1.2.10.

Regards,

Patrice
