### PR TITLE
Fixed error in GelfLayout

### DIFF
--- a/src/Gelf4net/Layout/GelfLayout.cs
+++ b/src/Gelf4net/Layout/GelfLayout.cs
@@ -202,7 +202,7 @@ namespace gelf4net.Layout
                 var key = kvp.Key.StartsWith("_") ? kvp.Key : "_" + kvp.Key;
 
                 //If the value starts with a '%' then defer to the pattern layout
-                var value = kvp.Value.StartsWith("%") ? GetValueFromPattern(loggingEvent, kvp.Value) : kvp.Value;
+                var value = kvp.Value == null ? String.Empty : (kvp.Value.StartsWith("%") ? GetValueFromPattern(loggingEvent, kvp.Value) : kvp.Value);
                 message[key] = value;
             }
         }

--- a/src/Gelf4netTests/Layout/GelfLayoutTests.cs
+++ b/src/Gelf4netTests/Layout/GelfLayoutTests.cs
@@ -262,6 +262,19 @@ namespace Gelf4netTest.Layout
             Assert.IsNotNullOrEmpty(result.File);
         }
 
+        [Test]
+        public void NullPropertyValueDoesNotCauseException()
+        {
+            var layout = new GelfLayout();
+            layout.IncludeLocationInformation = true;
+
+            var message = "test";
+            var loggingEvent = GetLogginEvent(message);
+            loggingEvent.Properties["nullProperty"] = null;
+
+            Assert.DoesNotThrow(() => GetMessage(layout, loggingEvent));
+        }
+
         private GelfMessage GetMessage(GelfLayout layout, LoggingEvent message)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
NullReferenceException was thrown if one of property values was null.

Proposed patch fixes it by checking for null before property value is appended to message.
There is also unit test for this case.
