### PR TITLE
No logging in appender.

### DIFF
--- a/src/Gelf4net/Appender/GelfUdpAppender.cs
+++ b/src/Gelf4net/Appender/GelfUdpAppender.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -97,7 +96,6 @@ namespace gelf4net.Appender
             var u = state.SendClient;
 
             var bytesSent = u.EndSend(ar);
-            Debug.WriteLine("Async bytes sent {0} chunk {1} of {2}", bytesSent, state.SendIndex, state.ChunkCount);
 
             state.SendIndex++;
             if (state.SendIndex < state.ChunkCount)


### PR DESCRIPTION
In some configurations Debug.WriteLine inside an appender could be risky. 
System.Diagnostics logging could be routed to log4net which uses gelf appender which logs using Debug.WriteLine which is routed to log4net...