### PR TITLE
Numeric additional fields should not be converted to strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ This will add the following additional fields to the output:
 ``` 
 
 Under the hood the `GelfLayout` class takes any object that is not a string and adds it's public 
-properties to a dictionary and converts their values in to strings. You can also pass in a dictionary 
+properties to a dictionary. All non-numeric values are then converted in to strings. You can also pass in a dictionary 
 directly and get the same output. When passing in a dictionary rather than using the public properties 
 of the object it uses the Key/Value pairs stored internally.
 

--- a/src/Gelf4net/Extensions.cs
+++ b/src/Gelf4net/Extensions.cs
@@ -4,13 +4,30 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Text;
 
 namespace gelf4net
 {
     public static class Extensions
     {
+        private static HashSet<Type> _numericTypes = new HashSet<Type>
+        {
+            typeof(decimal),
+            typeof(double),
+            typeof(float),
+            typeof(int),
+            typeof(uint),
+            typeof(long),
+            typeof(ulong),
+            typeof(short),
+            typeof(ushort)
+        };
+
+        public static bool IsNumeric(this Type type)
+        {
+            return _numericTypes.Contains(type);
+        }
+
         public static IDictionary ToDictionary(this object values)
         {
             var dict = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
@@ -44,7 +61,7 @@ namespace gelf4net
         {
             byte[] buffer = encoding.GetBytes(message);
             var ms = new MemoryStream();
-            using (var zip = new System.IO.Compression.GZipStream(ms, CompressionMode.Compress, true))
+            using (var zip = new GZipStream(ms, CompressionMode.Compress, true))
             {
                 zip.Write(buffer, 0, buffer.Length);
             }

--- a/src/Gelf4net/Layout/GelfLayout.cs
+++ b/src/Gelf4net/Layout/GelfLayout.cs
@@ -212,7 +212,7 @@ namespace gelf4net.Layout
                 else
                 {
                     key = key.StartsWith("_") ? key : "_" + key;
-                    gelfMessage[key] = value;
+                    gelfMessage[key] = FormatAdditionalField(entry.Value);
                 }
             }
         }
@@ -225,7 +225,7 @@ namespace gelf4net.Layout
                 var key = item.Key as string;
                 if (key != null && !key.StartsWith("log4net:") /*exclude log4net built-in properties */ )
                 {
-                    additionalFields.Add(key, item.Value);
+                    additionalFields.Add(key, FormatAdditionalField(item.Value));
                 }
             }
 
@@ -238,6 +238,11 @@ namespace gelf4net.Layout
                 var value = patternValue != null && patternValue.StartsWith("%") ? GetValueFromPattern(loggingEvent, patternValue) : kvp.Value;
                 message[key] = value;
             }
+        }
+
+        private object FormatAdditionalField(object value)
+        {
+            return value == null || value.GetType().IsNumeric() ? value : value.ToString();
         }
 
         private string GetValueFromPattern(LoggingEvent loggingEvent, string pattern)

--- a/src/Gelf4netTests/Layout/GelfLayoutTests.cs
+++ b/src/Gelf4netTests/Layout/GelfLayoutTests.cs
@@ -56,7 +56,7 @@ namespace Gelf4netTest.Layout
 
             var result = GetMessage(layout, loggingEvent);
 
-            Assert.AreEqual(result["_Test"], message.Test.ToString());
+            Assert.AreEqual(result["_Test"], message.Test);
             Assert.AreEqual(result["_Test2"], message.Test2);
         }
 
@@ -75,6 +75,57 @@ namespace Gelf4netTest.Layout
 
             Assert.AreEqual(result.FullMessage, message);
             Assert.AreEqual(result["_TraceID"], 1);
+        }
+
+        [Test]
+        public void ObjectPropertiesConvertedToStrings()
+        {
+            var layout = new GelfLayout();
+
+            var message = "test";
+
+            var someObject = new object();
+            ThreadContext.Properties["obj"] = someObject;
+
+            var loggingEvent = GetLogginEvent(message);
+
+            var result = GetMessage(layout, loggingEvent);
+
+            Assert.AreEqual(result["_obj"], someObject.ToString());
+        }
+
+        [Test]
+        public void NumericPropertiesAreNotConvertedToStrings()
+        {
+            var layout = new GelfLayout();
+
+            var message = "test";
+
+            ThreadContext.Properties["decimal"] = 1m;
+            ThreadContext.Properties["double"] = 1d;
+            ThreadContext.Properties["float"] = 1f;
+            ThreadContext.Properties["int"] = 1;
+            ThreadContext.Properties["uint"] = (uint)1;
+            ThreadContext.Properties["long"] = 1L;
+            ThreadContext.Properties["ulong"] = 1ul;
+            ThreadContext.Properties["short"] = (short)1;
+            ThreadContext.Properties["ushort"] = (ushort)1;
+            ThreadContext.Properties["nullable"] = (int?)1;
+
+            var loggingEvent = GetLogginEvent(message);
+
+            var result = GetMessage(layout, loggingEvent);
+
+            Assert.AreEqual(result["_decimal"], 1);
+            Assert.AreEqual(result["_double"], 1);
+            Assert.AreEqual(result["_float"], 1);
+            Assert.AreEqual(result["_int"], 1);
+            Assert.AreEqual(result["_uint"], 1);
+            Assert.AreEqual(result["_long"], 1);
+            Assert.AreEqual(result["_ulong"], 1);
+            Assert.AreEqual(result["_short"], 1);
+            Assert.AreEqual(result["_ushort"], 1);
+            Assert.AreEqual(result["_nullable"], 1);
         }
 
         [Test]
@@ -121,7 +172,7 @@ namespace Gelf4netTest.Layout
             var result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.FullMessage, message.Message);
-            Assert.AreEqual(result["_Test"], message.Test.ToString());
+            Assert.AreEqual(result["_Test"], message.Test);
 
             var message2 = new { FullMessage = "Success", Test = 1 };
             loggingEvent = GetLogginEvent(message2);
@@ -129,21 +180,21 @@ namespace Gelf4netTest.Layout
 
 
             Assert.AreEqual(result.FullMessage, message2.FullMessage);
-            Assert.AreEqual(result["_Test"], message2.Test.ToString());
+            Assert.AreEqual(result["_Test"], message2.Test);
 
             var message3 = new { message = "Success", Test = 1 };
             loggingEvent = GetLogginEvent(message3);
             result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.FullMessage, message3.message);
-            Assert.AreEqual(result["_Test"], message3.Test.ToString());
+            Assert.AreEqual(result["_Test"], message3.Test);
 
             var message4 = new { full_Message = "Success", Test = 1 };
             loggingEvent = GetLogginEvent(message4);
             result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.FullMessage, message4.full_Message);
-            Assert.AreEqual(result["_Test"], message4.Test.ToString());
+            Assert.AreEqual(result["_Test"], message4.Test);
         }
 
         [Test]
@@ -156,14 +207,14 @@ namespace Gelf4netTest.Layout
             var result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.ShortMessage, message.ShortMessage);
-            Assert.AreEqual(result["_Test"], message.Test.ToString());
+            Assert.AreEqual(result["_Test"], message.Test);
 
             var message2 = new { short_message = "Success", Test = 1 };
             loggingEvent = GetLogginEvent(message2);
             result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.ShortMessage, message2.short_message);
-            Assert.AreEqual(result["_Test"], message2.Test.ToString());
+            Assert.AreEqual(result["_Test"], message2.Test);
 
             var message3 = new { message = "Success", Test = 1 };
             loggingEvent = GetLogginEvent(message3);
@@ -171,7 +222,7 @@ namespace Gelf4netTest.Layout
 
             Assert.AreEqual(result.FullMessage, message3.message);
             Assert.AreEqual(result.ShortMessage, message3.message);
-            Assert.AreEqual(result["_Test"], message3.Test.ToString());
+            Assert.AreEqual(result["_Test"], message3.Test);
 
             var message4 = new { message = "Success", short_message = "test", Test = 1 };
             loggingEvent = GetLogginEvent(message4);
@@ -179,7 +230,7 @@ namespace Gelf4netTest.Layout
 
             Assert.AreEqual(result.FullMessage, message4.message);
             Assert.AreEqual(result.ShortMessage, message4.short_message);
-            Assert.AreEqual(result["_Test"], message4.Test.ToString());
+            Assert.AreEqual(result["_Test"], message4.Test);
         }
 
         [Test]
@@ -297,8 +348,8 @@ namespace Gelf4netTest.Layout
 
             var result = GetMessage(layout, loggingEvent);
 
-            Assert.AreEqual(result["_Test"], message.Test.ToString());
-            Assert.AreEqual(result["_Test2"], message.Test2.ToString());
+            Assert.AreEqual(result["_Test"], message.Test);
+            Assert.AreEqual(result["_Test2"], message.Test2);
             Assert.AreEqual(result.FullMessage, message.ToString());
             Assert.AreEqual(result.ShortMessage, message.ToString().TruncateMessage(250));
         }

--- a/src/Gelf4netTests/Layout/GelfLayoutTests.cs
+++ b/src/Gelf4netTests/Layout/GelfLayoutTests.cs
@@ -74,7 +74,7 @@ namespace Gelf4netTest.Layout
             var result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.FullMessage, message);
-            Assert.AreEqual(result["_TraceID"], "1");
+            Assert.AreEqual(result["_TraceID"], 1);
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace Gelf4netTest.Layout
             var result = GetMessage(layout, loggingEvent);
 
             Assert.AreEqual(result.FullMessage, message);
-            Assert.AreEqual(result["_TraceID"], "1");
+            Assert.AreEqual(result["_TraceID"], 1);
         }
 
         [Test]


### PR DESCRIPTION
According to the GELF specification, additional fields could be sent either as a string or as a number. Currently only strings are supported. This pull request adds support for numbers. 
Numeric values allow Graylog to generate charts or calculate statistics.