### PR TITLE
Add root configuration section

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
 <settings>   
 	<repositoryPath>..\packages</repositoryPath>
 </settings>
+</configuration>


### PR DESCRIPTION
When trying to restore nuget packages in Visual Studio 2015, there is Error "nuget.config does not contain the expected root element 'configuration'.
After adding configuration as root section - packages restores.