### PR TITLE
Remove async from GelfUdpAppender.ActivateOptions()

### DIFF
--- a/src/Gelf4net/Appender/GelfUdpAppender.cs
+++ b/src/Gelf4net/Appender/GelfUdpAppender.cs
@@ -34,11 +34,11 @@ namespace Gelf4Net.Appender
             log4net.Util.TypeConverters.ConverterRegistry.AddConverter(typeof(IPAddress), new IPAddressConverter());
         }
 
-        public override async void ActivateOptions()
+        public override void ActivateOptions()
         {
             if (RemoteAddress == null)
             {
-                RemoteAddress = IPAddress.Parse(await GetIpAddressFromHostName());
+                RemoteAddress = IPAddress.Parse(GetIpAddressFromHostName().Result);
             }
 
             base.ActivateOptions();


### PR DESCRIPTION
Async caused System.InvalidOperationException in ASP.NET syncronization
context. "Async void" methods are generally unsupported within ASP.NET
request processing.