### PR TITLE
[WIP] Add Async http appender

### DIFF
--- a/src/Gelf4Net.AmqpAppender/AsyncGelfAmqpAppender.cs
+++ b/src/Gelf4Net.AmqpAppender/AsyncGelfAmqpAppender.cs
@@ -1,4 +1,5 @@
-﻿using log4net.Core;
+﻿using Gelf4Net.Util;
+using log4net.Core;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -8,15 +9,11 @@ namespace Gelf4Net.Appender
 {
     public class AsyncGelfAmqpAppender : GelfAmqpAppender
     {
-        private readonly ConcurrentQueue<byte[]> _pendingTasks;
-        private readonly ManualResetEvent _manualResetEvent;
-        private bool _onClosing;
+        private readonly BufferedLogSender _sender;
 
         public AsyncGelfAmqpAppender()
         {
-            _pendingTasks = new ConcurrentQueue<byte[]>();
-            _manualResetEvent = new ManualResetEvent(false);
-            Start();
+            _sender = new BufferedLogSender(SendMessageAsync);
         }
 
         protected override void Append(LoggingEvent[] loggingEvents)
@@ -31,56 +28,14 @@ namespace Gelf4Net.Appender
         {
             if (FilterEvent(loggingEvent))
             {
-                _pendingTasks.Enqueue(this.RenderLoggingEvent(loggingEvent).GzipMessage(this.Encoding));
+                _sender.QueueSend(this.RenderLoggingEvent(loggingEvent));
             }
         }
-
-        private void Start()
-        {
-            if (_onClosing)
-            {
-                return;
-            }
-            var thread = new Thread(LogMessages);
-            thread.Start();
-        }
-
-        private void LogMessages()
-        {
-            while (!_onClosing)
-            {
-                byte[] loggingEvent;
-                while (!_pendingTasks.TryDequeue(out loggingEvent))
-                {
-                    Thread.Sleep(10);
-                    if (_onClosing)
-                    {
-                        try
-                        {
-                            base.SendMessage(_pendingTasks.ToArray());
-                            break;
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine(ex);
-                            break;
-                        }
-                    }
-                }
-                if (loggingEvent != null)
-                {
-                    base.SendMessage(loggingEvent);
-                }
-            }
-            _manualResetEvent.Set();
-        }
-
+        
         protected override void OnClose()
         {
             Debug.WriteLine("Closing Async Appender");
-            _onClosing = true;
-            _manualResetEvent.WaitOne(TimeSpan.FromSeconds(10));
-            Debug.WriteLine("Logging thread has stopped");
+            _sender.Stop();
             base.OnClose();
         }
     }

--- a/src/Gelf4Net.AmqpAppender/GelfAmqpAppender.cs
+++ b/src/Gelf4Net.AmqpAppender/GelfAmqpAppender.cs
@@ -3,6 +3,7 @@ using RabbitMQ.Client;
 using System;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Gelf4Net.Appender
 {
@@ -62,6 +63,12 @@ namespace Gelf4Net.Appender
             }
         }
 
+        protected Task SendMessageAsync(string logMessage)
+        {
+            SendMessage(logMessage.GzipMessage(Encoding));
+            return CompletedTask;
+        }
+
         protected void SendMessage(byte[] payload)
         {
             if (WaitForConnectionToConnectOrReconnect(new TimeSpan(0, 0, 0, 0, 500)))
@@ -102,5 +109,12 @@ namespace Gelf4Net.Appender
                 Connection.Dispose();
             }
         }
+
+#if NETSTANDARD1_5
+        private static Task CompletedTask = Task.CompletedTask;
+#else
+        private static Task CompletedTask = Task.FromResult<bool>(true);
+#endif
+
     }
 }

--- a/src/Gelf4Net.Core/Util/BufferedLogSender.cs
+++ b/src/Gelf4Net.Core/Util/BufferedLogSender.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gelf4Net.Util
+{
+    public class BufferedLogSender
+    {
+        private readonly BlockingCollection<string> _pendingTasks;
+        private readonly CancellationTokenSource _cts;
+        private readonly Func<string, Task> _sendFunc;
+        private readonly Task _sender;
+
+        public BufferedLogSender(Func<string, Task> sendFunc)
+        {
+            _pendingTasks = new BlockingCollection<string>(100);
+            _cts = new CancellationTokenSource();
+            _sendFunc = sendFunc;
+            // FIXME: use the machine's core count?
+            _sender = Task.WhenAll(Enumerable.Range(1, 4).Select(_ => Task.Run(SendMessagesAsync)));
+        }
+
+        private async Task SendMessagesAsync()
+        {
+            Debug.WriteLine("[Gelf4Net] Start Buffered Log Sender");
+            var token = _cts.Token;
+            while (!_cts.IsCancellationRequested)
+            {
+                var loggingEvent = _pendingTasks.Take(token);
+                if (loggingEvent != null)
+                {
+                    await _sendFunc(loggingEvent);
+                }
+            }
+            Debug.WriteLine("[Gelf4Net] Stop Buffered Log Sender");
+        }
+
+        public void QueueSend(string renderedLogLine)
+        {
+            _pendingTasks.Add(renderedLogLine);
+        }
+
+        public void Stop()
+        {
+            _cts.Cancel();
+            Task.WaitAny(new[] { _sender }, TimeSpan.FromSeconds(10));
+            Debug.WriteLine("Logging thread has stopped");
+        }
+    }
+}

--- a/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
+++ b/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
@@ -1,0 +1,61 @@
+﻿using log4net.Core;
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gelf4Net.Appender
+{
+    public class AsyncGelfHttpAppender : GelfHttpAppender
+    {
+        private readonly BlockingCollection<string> _pendingTasks;
+        private readonly CancellationTokenSource _cts;
+        private readonly Task _sender;
+
+        public AsyncGelfHttpAppender()
+        {
+            _pendingTasks = new BlockingCollection<string>();
+            _cts = new CancellationTokenSource();
+            _sender = Task.Run(SendMessagesAsync);
+        }
+
+        protected override void Append(LoggingEvent[] loggingEvents)
+        {
+            foreach (var loggingEvent in loggingEvents)
+            {
+                Append(loggingEvent);
+            }
+        }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            if (FilterEvent(loggingEvent))
+            {
+                _pendingTasks.Add(RenderLoggingEvent(loggingEvent));
+            }
+        }
+
+        private async Task SendMessagesAsync()
+        {
+            var token = _cts.Token;
+            while (!_cts.IsCancellationRequested)
+            {
+                var loggingEvent = _pendingTasks.Take(token);
+                if (loggingEvent != null)
+                {
+                    await base.SendMessageAsync(loggingEvent);
+                }
+            }
+        }
+
+        protected override void OnClose()
+        {
+            Debug.WriteLine("Closing Async Appender");
+            _cts.Cancel();
+            Task.WaitAny(new[] { _sender }, TimeSpan.FromSeconds(10));
+            Debug.WriteLine("Logging thread has stopped");
+            base.OnClose();
+        }
+    }
+}

--- a/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
+++ b/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,9 +16,10 @@ namespace Gelf4Net.Appender
 
         public AsyncGelfHttpAppender()
         {
-            _pendingTasks = new BlockingCollection<string>();
+            _pendingTasks = new BlockingCollection<string>(100);
             _cts = new CancellationTokenSource();
-            _sender = Task.Run(SendMessagesAsync);
+            // FIXME: use the machine's core count?
+            _sender = Task.WhenAll(Enumerable.Range(1, 4).Select(_ => Task.Run(SendMessagesAsync)));
         }
 
         protected override void Append(LoggingEvent[] loggingEvents)

--- a/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
+++ b/src/Gelf4Net.HttpAppender/AsyncGelfHttpAppender.cs
@@ -1,25 +1,16 @@
-﻿using log4net.Core;
-using System;
-using System.Collections.Concurrent;
+﻿using Gelf4Net.Util;
+using log4net.Core;
 using System.Diagnostics;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Gelf4Net.Appender
 {
     public class AsyncGelfHttpAppender : GelfHttpAppender
     {
-        private readonly BlockingCollection<string> _pendingTasks;
-        private readonly CancellationTokenSource _cts;
-        private readonly Task _sender;
+        private readonly BufferedLogSender _sender;
 
         public AsyncGelfHttpAppender()
         {
-            _pendingTasks = new BlockingCollection<string>(100);
-            _cts = new CancellationTokenSource();
-            // FIXME: use the machine's core count?
-            _sender = Task.WhenAll(Enumerable.Range(1, 4).Select(_ => Task.Run(SendMessagesAsync)));
+            _sender = new BufferedLogSender(SendMessageAsync);
         }
 
         protected override void Append(LoggingEvent[] loggingEvents)
@@ -34,29 +25,14 @@ namespace Gelf4Net.Appender
         {
             if (FilterEvent(loggingEvent))
             {
-                _pendingTasks.Add(RenderLoggingEvent(loggingEvent));
-            }
-        }
-
-        private async Task SendMessagesAsync()
-        {
-            var token = _cts.Token;
-            while (!_cts.IsCancellationRequested)
-            {
-                var loggingEvent = _pendingTasks.Take(token);
-                if (loggingEvent != null)
-                {
-                    await base.SendMessageAsync(loggingEvent);
-                }
+                _sender.QueueSend(RenderLoggingEvent(loggingEvent));
             }
         }
 
         protected override void OnClose()
         {
             Debug.WriteLine("Closing Async Appender");
-            _cts.Cancel();
-            Task.WaitAny(new[] { _sender }, TimeSpan.FromSeconds(10));
-            Debug.WriteLine("Logging thread has stopped");
+            _sender.Stop();
             base.OnClose();
         }
     }

--- a/src/Gelf4Net.HttpAppender/GelfHttpAppender.cs
+++ b/src/Gelf4Net.HttpAppender/GelfHttpAppender.cs
@@ -42,14 +42,20 @@ namespace Gelf4Net.Appender
         protected override void Append(LoggingEvent loggingEvent)
         {
             var payload = RenderLoggingEvent(loggingEvent);
+            SendMessageAsync(payload);
+        }
+
+        protected Task SendMessageAsync(string payload)
+        {
             var content = new StringContent(payload, Encoding.UTF8, "application/json");
-            _httpClient.PostAsync(_baseUrl, content).ContinueWith(CallBackAfterPost);
+            return _httpClient.PostAsync(_baseUrl, content)
+                .ContinueWith(CallBackAfterPost);
         }
 
         private void CallBackAfterPost(Task<HttpResponseMessage> obj)
         {
             if (obj.Exception != null)
-              ErrorHandler.Error("Unable to send logging event to remote host " + this.Url, obj.Exception);
+              ErrorHandler.Error("Unable to send logging event to remote host " + Url, obj.Exception);
         }
     }
 }

--- a/src/Gelf4Net.HttpAppender/GelfHttpAppender.cs
+++ b/src/Gelf4Net.HttpAppender/GelfHttpAppender.cs
@@ -42,20 +42,23 @@ namespace Gelf4Net.Appender
         protected override void Append(LoggingEvent loggingEvent)
         {
             var payload = RenderLoggingEvent(loggingEvent);
-            SendMessageAsync(payload);
+            var _ = SendMessageAsync(payload);
         }
 
-        protected Task SendMessageAsync(string payload)
+        protected async Task SendMessageAsync(string payload)
         {
-            var content = new StringContent(payload, Encoding.UTF8, "application/json");
-            return _httpClient.PostAsync(_baseUrl, content)
-                .ContinueWith(CallBackAfterPost);
-        }
-
-        private void CallBackAfterPost(Task<HttpResponseMessage> obj)
-        {
-            if (obj.Exception != null)
-              ErrorHandler.Error("Unable to send logging event to remote host " + Url, obj.Exception);
+            try
+            {
+                using (var content = new ByteArrayContent(payload.GzipMessage(Encoding.UTF8)))
+                {
+                    content.Headers.ContentEncoding.Add("gzip");
+                    await _httpClient.PostAsync(_baseUrl, content);
+                }
+            }
+            catch (Exception e)
+            {
+                ErrorHandler.Error("Unable to send logging event to remote host " + Url, e);
+            }
         }
     }
 }

--- a/src/Gelf4Net.UdpAppender/AsyncGelfUdpAppender.cs
+++ b/src/Gelf4Net.UdpAppender/AsyncGelfUdpAppender.cs
@@ -1,4 +1,5 @@
-﻿using log4net.Core;
+﻿using Gelf4Net.Util;
+using log4net.Core;
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics;
@@ -8,15 +9,11 @@ namespace Gelf4Net.Appender
 {
     public class AsyncGelfUdpAppender : GelfUdpAppender
     {
-        private readonly ConcurrentQueue<byte[]> _pendingTasks;
-        private readonly ManualResetEvent _manualResetEvent;
-        private bool _onClosing;
+        private readonly BufferedLogSender _sender;
 
         public AsyncGelfUdpAppender()
         {
-            _pendingTasks = new ConcurrentQueue<byte[]>();
-            _manualResetEvent = new ManualResetEvent(false);
-            Start();
+            _sender = new BufferedLogSender(SendMessageAsync);
         }
 
         protected override void Append(LoggingEvent[] loggingEvents)
@@ -31,60 +28,14 @@ namespace Gelf4Net.Appender
         {
             if (FilterEvent(loggingEvent))
             {
-                _pendingTasks.Enqueue(this.RenderLoggingEvent(loggingEvent).GzipMessage(this.Encoding));
+                _sender.QueueSend(RenderLoggingEvent(loggingEvent));
             }
-        }
-
-        private void Start()
-        {
-            Debug.WriteLine("[Gelf4Net] Start Async Appender");
-            if (_onClosing)
-            {
-                Debug.WriteLine("[Gelf4Net] Closing");
-                return;
-            }
-            var thread = new Thread(LogMessages);
-            thread.Start();
-        }
-
-        private void LogMessages()
-        {
-            while (!_onClosing)
-            {
-                byte[] loggingEvent;
-                while (!_pendingTasks.TryDequeue(out loggingEvent))
-                {
-                    Thread.Sleep(10);
-                    if (_onClosing)
-                    {
-                        try
-                        {
-                            Debug.WriteLine("[Gelf4Net] Appending");
-                            base.SendMessage(_pendingTasks.ToArray());
-                            break;
-                        }
-                        catch (Exception ex)
-                        {
-                            Debug.WriteLine(ex);
-                            break;
-                        }
-                    }
-                }
-                if (loggingEvent != null)
-                {
-                    Debug.WriteLine("[Gelf4Net] Appending 2");
-                    base.SendMessage(loggingEvent);
-                }
-            }
-            _manualResetEvent.Set();
         }
 
         protected override void OnClose()
         {
             Debug.WriteLine("[Gelf4Net] Closing Async Appender");
-            _onClosing = true;
-            _manualResetEvent.WaitOne(TimeSpan.FromSeconds(10));
-            Debug.WriteLine("[Gelf4Net] Logging thread has stopped");
+            _sender.Stop();
             base.OnClose();
         }
     }

--- a/src/Gelf4Net.UdpAppender/GelfUdpAppender.cs
+++ b/src/Gelf4Net.UdpAppender/GelfUdpAppender.cs
@@ -72,9 +72,14 @@ namespace Gelf4Net.Appender
             }
         }
 
-        protected void SendMessage(byte[] payload)
+        protected Task SendMessageAsync(string logMessage)
         {
-            Task.Run(async () =>
+            return SendMessage(logMessage.GzipMessage(Encoding));
+        }
+
+        protected Task SendMessage(byte[] payload)
+        {
+            return Task.Run(async () =>
             {
                 try
                 {


### PR DESCRIPTION
Creates a new `AsyncGelfHttpAppender` which performs logging in the background as the other `Async*` appenders do.

This PR also makes a few refactorings to share code more amongst the async appenders:

 * `BufferedLogSender` is added. This is responsible for queing and sending messages in the background
 * Switch to `Task` for background processing. Uses `async` operations when sending data.
 * Move to `BlockingCollection` for buffer of lines to send. This should be faster in this producer-consumer scenario.
 * Move to `CancellationTokenSource` and `CancellationToken` for cancellation of the background processing.

Still TODO:

 * [ ] Choose a `Task` count based on a parameter rather than hardcoding it
 * [ ] Choose a buffer size based on a parameter rather than hardcoding.
