### PR TITLE
As of log4net 3.0.0: Fixed invalid cast

### DIFF
--- a/src/Gelf4Net.Core/Gelf4Net.Core.csproj
+++ b/src/Gelf4Net.Core/Gelf4Net.Core.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' != 'net462' ">
-    <PackageReference Include="log4net" Version="2.0.15" />
+    <PackageReference Include="log4net" Version="3.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   

--- a/src/Gelf4Net.Core/Layout/GelfLayout.cs
+++ b/src/Gelf4Net.Core/Layout/GelfLayout.cs
@@ -230,9 +230,9 @@ namespace Gelf4Net.Layout
         private void AddAdditionalFields(LoggingEvent loggingEvent, GelfMessage message)
         {
             var additionalFields = ParseField(AdditionalFields) ?? new Dictionary<string, object>();
-            foreach (DictionaryEntry item in loggingEvent.GetProperties())
+            foreach (KeyValuePair<string,object?> item in loggingEvent.GetProperties())
             {
-                var key = item.Key as string;
+                var key = item.Key;
                 if (key != null && !key.StartsWith("log4net:") /*exclude log4net built-in properties */ )
                 {
                     additionalFields.Add(key, FormatAdditionalField(item.Value));


### PR DESCRIPTION

As of log4net 3.0.0 Enumerator of PropertiesDirectory (returned by loggingEvent.GetProperties()) is the enumerator of an IDictionary<string,object?>.

Prior to this commit using the Layout throws an InvalidCast exception. 

I would appreciate a rather quick fix including new nuget release including updated log4net dependency.